### PR TITLE
Fix header label in index template

### DIFF
--- a/src/songripper/templates/index.html
+++ b/src/songripper/templates/index.html
@@ -14,7 +14,7 @@
   <p id="message">{{ message }}</p>
 {% endif %}
 </div>
-<h2>Rip YouTube</h2>
+<h2>Song Duplicate Checker</h2>
 <div id="spinner" aria-hidden="true"></div>
 <form hx-post="/rip" hx-swap="none" hx-indicator="#spinner"
       hx-on:afterRequest="document.body.dispatchEvent(new Event('refreshStaging'))">


### PR DESCRIPTION
## Summary
- update the main page header to read "Song Duplicate Checker"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804b6b29a8832c8c816552d9df83bb