### PR TITLE
Add audio file scanner

### DIFF
--- a/src/sdc/scanner.py
+++ b/src/sdc/scanner.py
@@ -1,0 +1,23 @@
+"""Utilities for scanning directories for audio files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+AUDIO_EXTS: set[str] = {".mp3", ".flac", ".wav", ".m4a"}
+
+
+def yield_audio_files(root: str | Path) -> Iterator[Path]:
+    """Yield audio file paths found under ``root``.
+
+    Only files with extensions listed in :data:`AUDIO_EXTS` are returned. The
+    search is recursive and results are yielded in sorted order.
+    """
+    path = Path(root)
+    for p in sorted(path.rglob("*")):
+        if p.is_file() and p.suffix.lower() in AUDIO_EXTS:
+            yield p
+
+
+__all__ = ["yield_audio_files", "AUDIO_EXTS"]

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from sdc.scanner import yield_audio_files
+
+
+def test_yield_audio_files(tmp_path):
+    files = [
+        tmp_path / "a.mp3",
+        tmp_path / "b.flac",
+        tmp_path / "sub" / "c.wav",
+        tmp_path / "d.txt",
+        tmp_path / "e.m4a",
+    ]
+    (tmp_path / "sub").mkdir()
+    for f in files:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("x")
+    result = list(yield_audio_files(tmp_path))
+    expected = [files[0], files[1], files[2], files[4]]
+    assert result == sorted(expected)


### PR DESCRIPTION
## Summary
- add a scanner utility for yielding audio files
- test scanner for supported extensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880da079740832cae21db95bad48217