### PR TITLE
Implement media tag extraction

### DIFF
--- a/src/songripper/media.py
+++ b/src/songripper/media.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class MediaInfo:
+    """Simple container for basic audio metadata."""
+
+    title: str
+    artist: str
+    album: str
+    length: float
+    bitrate: int
+
+
+def _get_first(value: Any) -> str | None:
+    """Return the first element from a tag value."""
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return str(value[0]) if value else None
+    if hasattr(value, "text"):
+        text = value.text
+        if isinstance(text, list):
+            return str(text[0]) if text else None
+        return str(text)
+    return str(value)
+
+
+def read_media_info(path: str | Path) -> MediaInfo:
+    """Return :class:`MediaInfo` for ``path`` using mutagen when available."""
+
+    filepath = Path(path)
+    title = filepath.stem
+    album = filepath.parent.name
+    artist = filepath.parents[1].name if len(filepath.parents) > 1 else ""
+    length = 0.0
+    bitrate = 0
+
+    try:
+        from mutagen import File as MutagenFile  # type: ignore
+    except Exception:
+        MutagenFile = None
+
+    if MutagenFile is not None:
+        try:
+            audio = MutagenFile(filepath)
+        except Exception:
+            audio = None
+        if audio is not None:
+            tags = getattr(audio, "tags", None)
+            if tags:
+                title = _get_first(tags.get("title")) or title
+                artist = _get_first(tags.get("artist")) or artist
+                album = _get_first(tags.get("album")) or album
+            info = getattr(audio, "info", None)
+            if info is not None:
+                length = getattr(info, "length", length)
+                br = getattr(info, "bitrate", None)
+                if br:
+                    bitrate = int(br / 1000)
+
+    return MediaInfo(title=title, artist=artist, album=album, length=length, bitrate=bitrate)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from songripper.media import read_media_info, MediaInfo
+
+
+def test_read_media_info_uses_mutagen(monkeypatch, tmp_path):
+    class DummyAudio:
+        def __init__(self):
+            self.tags = {
+                "title": ["Title"],
+                "artist": ["Artist"],
+                "album": ["Album"],
+            }
+            self.info = types.SimpleNamespace(length=123.4, bitrate=256000)
+
+    def fake_file(path):
+        return DummyAudio()
+
+    monkeypatch.setitem(sys.modules, "mutagen", types.SimpleNamespace(File=fake_file))
+
+    p = tmp_path / "song.mp3"
+    p.write_text("x")
+    info = read_media_info(p)
+    assert isinstance(info, MediaInfo)
+    assert info.title == "Title"
+    assert info.artist == "Artist"
+    assert info.album == "Album"
+    assert info.length == 123.4
+    assert info.bitrate == 256
+
+
+def test_read_media_info_fallback(monkeypatch, tmp_path):
+    def fake_file(path):
+        raise RuntimeError("boom")
+
+    monkeypatch.setitem(sys.modules, "mutagen", types.SimpleNamespace(File=fake_file))
+
+    path = tmp_path / "Artist" / "Album" / "Song.mp3"
+    path.parent.mkdir(parents=True)
+    path.write_text("x")
+    info = read_media_info(path)
+    assert info.artist == "Artist"
+    assert info.album == "Album"
+    assert info.title == "Song"
+    assert info.length == 0.0
+    assert info.bitrate == 0


### PR DESCRIPTION
## Summary
- add `MediaInfo` dataclass and a `read_media_info` helper to read tags from files using mutagen
- test metadata extraction with and without mutagen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fbcea48c832c92e32f86ee31925b