### PR TITLE
Implement path hashing for tracks

### DIFF
--- a/src/hash.py
+++ b/src/hash.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from hashlib import sha1
+from pathlib import Path
+
+
+def path_hash(path: str | Path) -> str:
+    """Return SHA-1 hexdigest of the relative ``path``.
+
+    The function normalizes path separators so that the result is
+    platform independent.
+    """
+    p = Path(path)
+    rel = p.as_posix()
+    return sha1(rel.encode("utf-8")).hexdigest()
+
+
+__all__ = ["path_hash"]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from sdc.database import open_db, Track
+from hash import path_hash
 
 
 def test_open_db_returns_engine(tmp_path):
@@ -14,7 +15,8 @@ def test_open_db_returns_engine(tmp_path):
 
 
 def test_track_model_has_fields():
-    t = Track(path="x")
+    t = Track(path="x", path_hash=path_hash("x"))
     assert hasattr(t, "id")
     assert hasattr(t, "path")
+    assert hasattr(t, "path_hash")
 

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,0 +1,12 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from hash import path_hash
+
+
+def test_path_hash_deterministic():
+    p = Path('a/b/c.mp3')
+    assert path_hash(p) == 'ca92091e97794429e492680080d17066653c96e3'

--- a/tests/test_scan_db.py
+++ b/tests/test_scan_db.py
@@ -6,6 +6,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from sdc.database import open_db, scan_to_db
+from hash import path_hash
 
 
 
@@ -20,8 +21,11 @@ def test_scan_to_db_inserts_files(tmp_path):
         f.write_text("x")
     scan_to_db(tmp_path, engine)
     with sqlite3.connect(db) as conn:
-        rows = sorted(r[0] for r in conn.execute("SELECT path FROM track"))
-    assert rows == [str(f1), str(f2)]
+        rows = sorted(conn.execute("SELECT path, path_hash FROM track").fetchall())
+    assert rows == [
+        (str(f1), path_hash(f1.relative_to(tmp_path))),
+        (str(f2), path_hash(f2.relative_to(tmp_path))),
+    ]
 
 
 def test_scan_to_db_is_idempotent(tmp_path):


### PR DESCRIPTION
## Summary
- add `hash.path_hash` utility to hash relative paths
- store `path_hash` alongside paths when scanning
- ensure `Track` model exposes new `path_hash` attribute
- add unit tests for hashing and updated database behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813a08555c832c873873987307405e