### PR TITLE
Implement duplicate scoring

### DIFF
--- a/src/duplicate_finder.py
+++ b/src/duplicate_finder.py
@@ -4,8 +4,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 import sqlite3
+from difflib import SequenceMatcher
 
 from audio import fingerprint
+from heuristics import FP_WEIGHT, TAG_WEIGHT, FUZZY_WEIGHT
 
 
 @dataclass
@@ -13,11 +15,21 @@ class DuplicateGroup:
     """Collection of files considered duplicates."""
 
     files: List[str]
+    score: float
+
+    @property
+    def is_confident(self) -> bool:
+        """Return ``True`` when ``score`` meets the duplicate threshold."""
+        return self.score >= 0.8
 
 
 def _get_db_path(session: object) -> Path:
     """Return the SQLite database path for ``session`` or ``engine``."""
-    engine = getattr(session, "engine", session)
+    engine = getattr(session, "engine", None)
+    if engine is None and hasattr(session, "get_bind"):
+        engine = session.get_bind()
+    if engine is None:
+        engine = session
     url = getattr(engine, "url", engine)
     if hasattr(url, "database"):
         return Path(url.database)
@@ -26,21 +38,64 @@ def _get_db_path(session: object) -> Path:
     return Path(str(url))
 
 
+def _extract_tags(path: str | Path) -> tuple[str, str, str]:
+    """Return ``artist``, ``album`` and ``title`` extracted from ``path``."""
+    p = Path(path)
+    artist = p.parents[1].name if len(p.parents) > 1 else ""
+    album = p.parent.name
+    title = p.stem
+    return artist.lower(), album.lower(), title.lower()
+
+
+def _score_pair(p1: str, p2: str, fp1: int, fp2: int) -> float:
+    """Return similarity score for two tracks."""
+    diff = bin(fp1 ^ fp2).count("1")
+    fp_sim = 1.0 - diff / 32.0
+    a1, alb1, t1 = _extract_tags(p1)
+    a2, alb2, t2 = _extract_tags(p2)
+    tag_sim = 1.0 if (a1 == a2 and alb1 == alb2 and t1 == t2) else 0.0
+    fuzzy_sim = SequenceMatcher(None, t1, t2).ratio()
+    return FP_WEIGHT * fp_sim + TAG_WEIGHT * tag_sim + FUZZY_WEIGHT * fuzzy_sim
+
+
+def calculate_score(paths: List[str], fps: List[int]) -> float:
+    """Return average pairwise similarity for ``paths``."""
+    n = len(paths)
+    if n < 2:
+        return 0.0
+    total = 0.0
+    count = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            total += _score_pair(paths[i], paths[j], fps[i], fps[j])
+            count += 1
+    return round(total / count, 4) if count else 0.0
+
+
 def find_duplicates(session: object) -> List[DuplicateGroup]:
     """Return groups of files with matching audio fingerprints."""
     db_path = _get_db_path(session)
     with sqlite3.connect(db_path) as conn:
         rows = list(conn.execute("SELECT path FROM track"))
-    fps: dict[int, List[str]] = {}
+    by_fp: dict[int, List[tuple[str, int]]] = {}
     for (path,) in rows:
         try:
             fp = fingerprint(path)
         except Exception:
             fp = 0
-        fps.setdefault(fp, []).append(path)
+        by_fp.setdefault(fp, []).append((path, fp))
 
-    groups = [DuplicateGroup(sorted(paths)) for paths in fps.values() if len(paths) > 1]
+    groups: List[DuplicateGroup] = []
+    for entries in by_fp.values():
+        if len(entries) <= 1:
+            continue
+        files = [p for p, _ in entries]
+        fps = [fp for _, fp in entries]
+        score = calculate_score(files, fps)
+        if score >= 0.8:
+            groups.append(DuplicateGroup(sorted(files), score))
+
     groups.sort(key=lambda g: g.files)
     return groups
 
-__all__ = ["DuplicateGroup", "find_duplicates"]
+__all__ = ["DuplicateGroup", "find_duplicates", "calculate_score"]

--- a/tests/test_duplicate_finder.py
+++ b/tests/test_duplicate_finder.py
@@ -5,7 +5,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from sdc.database import open_db, scan_to_db, Session
-from duplicate_finder import find_duplicates, DuplicateGroup
+from duplicate_finder import find_duplicates, DuplicateGroup, calculate_score
 import audio
 
 
@@ -22,10 +22,24 @@ def test_find_duplicates_detects_copies(tmp_path, monkeypatch):
 
     # Monkeypatch fingerprint to avoid ffmpeg dependency
     monkeypatch.setattr(audio, "fingerprint", lambda p: 123)
+    monkeypatch.setattr("duplicate_finder.fingerprint", lambda p: 123)
 
     scan_to_db(tmp_path, engine)
 
     with Session(engine) as session:
         groups = find_duplicates(session)
 
-    assert groups == [DuplicateGroup(files=sorted([str(f1), str(f2)]))]
+    assert len(groups) == 1
+    g = groups[0]
+    assert g.files == sorted([str(f1), str(f2)])
+    assert g.score >= 0.8
+
+
+def test_calculate_score_low_for_different_songs(tmp_path, monkeypatch):
+    f1 = tmp_path / "a" / "song1.m4a"
+    f2 = tmp_path / "b" / "song2.m4a"
+    f1.parent.mkdir(parents=True, exist_ok=True)
+    f2.parent.mkdir(parents=True, exist_ok=True)
+    fps = [123, 456]
+    score = calculate_score([str(f1), str(f2)], fps)
+    assert score < 0.7


### PR DESCRIPTION
## Summary
- add heuristic-based confidence scoring in duplicate_finder
- expose calculate_score helper
- only keep groups scoring at least 0.8
- test duplicate scoring behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816ed66c18832cb4b8b4cec3a8bd3b