### PR TITLE
Add duplicate action endpoint

### DIFF
--- a/src/sdc/api.py
+++ b/src/sdc/api.py
@@ -1,8 +1,10 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+import os
+import sqlite3
 
 from .worker import start_scan, get_status
 from .database import open_db, Session
-from duplicate_finder import find_duplicates
+from duplicate_finder import find_duplicates, _get_db_path
 from songripper.media import read_media_info
 
 app = FastAPI()
@@ -53,3 +55,38 @@ def list_duplicates() -> dict[str, object]:
             )
         result.append({"files": files, "confidence": g.score})
     return {"groups": result}
+
+
+@app.post("/duplicates/{group_id}/action")
+def duplicate_action(group_id: int, action: str) -> dict[str, object]:
+    """Perform an action on a duplicate group."""
+    engine = open_db()
+    with Session(engine) as session:
+        groups = find_duplicates(session)
+
+    if group_id < 0 or group_id >= len(groups):
+        raise HTTPException(status_code=404, detail="group not found")
+
+    group = groups[group_id]
+
+    if action == "keep_newest":
+        newest = max(group.files, key=lambda p: os.path.getmtime(p))
+        to_delete = [p for p in group.files if p != newest]
+    elif action == "trash":
+        to_delete = list(group.files)
+    else:
+        raise HTTPException(status_code=400, detail="invalid action")
+
+    db_path = _get_db_path(engine)
+    removed = 0
+    with sqlite3.connect(db_path) as conn:
+        for path in to_delete:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+            conn.execute("DELETE FROM track WHERE path=?", (path,))
+            removed += 1
+        conn.commit()
+
+    return {"status": "ok", "removed": removed}

--- a/tests/test_sdc_api.py
+++ b/tests/test_sdc_api.py
@@ -56,4 +56,54 @@ def test_duplicates_endpoint(monkeypatch):
                 "confidence": 0.95,
             }
         ]
-    }
+    } 
+
+
+def test_duplicate_action_keep_newest(monkeypatch):
+    engine = object()
+    monkeypatch.setattr(api, "open_db", lambda: engine)
+
+    class DummySession:
+        def __init__(self, engine):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(api, "Session", DummySession)
+
+    group = DuplicateGroup(files=["/a.mp3", "/b.mp3"], score=0.9)
+    monkeypatch.setattr(api, "find_duplicates", lambda session: [group])
+
+    monkeypatch.setattr(api, "_get_db_path", lambda e: "db")
+
+    times = {"/a.mp3": 2, "/b.mp3": 1}
+    monkeypatch.setattr(api.os.path, "getmtime", lambda p: times[p])
+
+    removed = []
+    monkeypatch.setattr(api.os, "remove", lambda p: removed.append(p))
+
+    class DummyConn:
+        def __init__(self):
+            self.calls = []
+        def execute(self, sql, params):
+            self.calls.append((sql, params))
+        def commit(self):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    conn = DummyConn()
+    monkeypatch.setattr(api.sqlite3, "connect", lambda p: conn)
+
+    resp = client.post(
+        "/duplicates/{group_id}/action",
+        data={"group_id": 0, "action": "keep_newest"},
+    )
+
+    assert resp == {"status": "ok", "removed": 1}
+    assert removed == ["/b.mp3"]
+    assert conn.calls == [("DELETE FROM track WHERE path=?", ("/b.mp3",))]


### PR DESCRIPTION
## Summary
- add endpoint for taking actions on duplicate groups
- test action endpoint with a mocked filesystem

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688180b7198c832caa65b3682010246b