### PR TITLE
Add Jinja2 base template with Tailwind

### DIFF
--- a/src/songripper/api.py
+++ b/src/songripper/api.py
@@ -1,11 +1,13 @@
 from pathlib import Path
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 
 from .settings import NAS_PATH
 from .worker import AUDIO_EXT
 
 app = FastAPI()
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 
 
 def _find_first_file(root: Path) -> Path | None:
@@ -17,8 +19,10 @@ def _find_first_file(root: Path) -> Path | None:
 
 
 @app.get("/", response_class=HTMLResponse)
-def home() -> HTMLResponse:
+def home(request: Request) -> HTMLResponse:
     path = _find_first_file(NAS_PATH)
-    if path is None:
-        return HTMLResponse("No files found")
-    return HTMLResponse(str(path))
+    message = str(path) if path is not None else "No files found"
+    return templates.TemplateResponse(
+        "base.html",
+        {"request": request, "message": message},
+    )

--- a/src/songripper/templates/base.html
+++ b/src/songripper/templates/base.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Song Duplicate Checker</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-100 min-h-screen flex flex-col">
+    <nav class="bg-blue-600 text-white py-4 shadow">
+        <div class="container mx-auto px-4">
+            <span class="font-semibold text-xl">SongDuplicateChecker</span>
+        </div>
+    </nav>
+    <main class="container mx-auto px-4 py-6 flex-1">
+        {{ message }}
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `base.html` template using Tailwind CDN with a simple navbar
- render the template from the home route using `Jinja2Templates`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818582b214832cbd957d181cf95016