### PR TITLE
Add scanning page with live progress

### DIFF
--- a/src/sdc/templates/scan.html
+++ b/src/sdc/templates/scan.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Scan</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <script src="https://unpkg.com/htmx.org@1.9.2"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex flex-col">
+    <nav class="bg-blue-600 text-white py-4 shadow">
+        <div class="container mx-auto px-4">
+            <span class="font-semibold text-xl">SongDuplicateChecker</span>
+        </div>
+    </nav>
+    <main class="container mx-auto px-4 py-6 flex-1">
+        <form id="scan-form" class="mb-4">
+            <label for="root" class="block text-sm font-medium text-gray-700 mb-2">Root directory</label>
+            <input id="root" name="root" type="text" class="border p-2 w-full mb-2" />
+            <button class="bg-blue-500 text-white px-4 py-2 rounded" type="submit">Start Scan</button>
+        </form>
+        <div id="progress"></div>
+    </main>
+    <script>
+    document.getElementById('scan-form').addEventListener('submit', async function(e){
+        e.preventDefault();
+        const form = e.target;
+        const data = new FormData(form);
+        const resp = await fetch('/scan', {method: 'POST', body: data});
+        const result = await resp.json();
+        const progress = document.getElementById('progress');
+        progress.setAttribute('hx-get', `/scan/${result.task_id}/progress`);
+        progress.setAttribute('hx-trigger', 'load, every 1s');
+        progress.setAttribute('hx-swap', 'innerHTML');
+        progress.innerHTML = 'Starting scan...';
+        htmx.process(progress);
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create scan template
- add `/scan` page with form
- poll `/scan/{id}/progress` for live updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688188467304832c8600b30e2f033049