### PR TITLE
Add duplicate management UI

### DIFF
--- a/src/sdc/api.py
+++ b/src/sdc/api.py
@@ -64,6 +64,12 @@ def scan_progress(job_id: int) -> HTMLResponse:
     return HTMLResponse(html)
 
 
+@app.get("/duplicates_table", response_class=HTMLResponse)
+def duplicates_table(request: Request) -> HTMLResponse:
+    """Render the duplicates table page."""
+    return templates.TemplateResponse("duplicates.html", {"request": request})
+
+
 @app.get("/duplicates")
 def list_duplicates() -> dict[str, object]:
     """Return groups of duplicate tracks with metadata."""

--- a/src/sdc/templates/duplicates.html
+++ b/src/sdc/templates/duplicates.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Duplicates</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <script src="https://unpkg.com/htmx.org@1.9.2"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex flex-col">
+    <nav class="bg-blue-600 text-white py-4 shadow">
+        <div class="container mx-auto px-4">
+            <span class="font-semibold text-xl">SongDuplicateChecker</span>
+        </div>
+    </nav>
+    <main class="container mx-auto px-4 py-6 flex-1">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead>
+                <tr>
+                    <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Files</th>
+                    <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody id="dup-body" class="divide-y divide-gray-200">
+            </tbody>
+        </table>
+    </main>
+    <script>
+    async function loadDuplicates(){
+        const resp = await fetch('/duplicates');
+        const data = await resp.json();
+        const body = document.getElementById('dup-body');
+        body.innerHTML = '';
+        data.groups.forEach((grp, idx) => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td class="px-3 py-2">
+                    ${grp.files.map(f => `
+                        <div class='mb-2'>
+                            <div class='text-sm'>${f.artist} - ${f.title}</div>
+                            <audio src="${f.path}" controls class='w-full'></audio>
+                        </div>
+                    `).join('')}
+                </td>
+                <td class="px-3 py-2">
+                    <button class="bg-blue-500 text-white px-3 py-1 rounded" 
+                        hx-post="/duplicates/${idx}/action" 
+                        hx-vals='{"action":"keep_newest"}' 
+                        hx-target="closest tr" 
+                        hx-swap="delete">
+                        Keep newest
+                    </button>
+                </td>`;
+            body.appendChild(tr);
+        });
+    }
+    loadDuplicates();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement an HTML page to show duplicate groups
- add endpoint to serve the duplicates table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818b5dd130832cb63d6b5e259315a2