### PR TITLE
Add README architecture diagram and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,42 @@
 # SongDuplicateCheckerV2
 
-SongDuplicateCheckerV2 is a small FastAPI service that will eventually scan a
-music library for newly added tracks and highlight possible duplicates. The
-scanner identifies matches using simple heuristics such as file size and title
-similarity and will provide options for how to handle each song when a
-duplicate is found.
+SongDuplicateCheckerV2 is a FastAPI service that scans a music library and highlights possible duplicates. It combines audio fingerprinting with simple heuristics to spot files that look alike so you can decide what to keep.
 
-At the moment the project exposes a minimal endpoint. When the root page (`/`)
-is requested, the app performs a recursive search starting from `NAS_PATH` and
-returns the path of the first audio file found. If no files are available the
-page simply displays "No files found".
+## Architecture
+
+```mermaid
+flowchart TD
+    Client[Browser/CLI] -->|HTTP| API(FastAPI app)
+    API -->|start scan| Worker
+    Worker -->|read files| FS[File system]
+    Worker --> DB[(SQLite DB)]
+    API --> DB
+    API -->|find duplicates| Finder[Duplicate Finder]
+    Finder --> DB
+    Finder --> FS
+```
+
+* **API** – endpoints in `sdc.api` expose scan and duplicate operations.
+* **Worker** – background thread in `sdc.worker` scans directories and records progress in SQLite.
+* **Duplicate Finder** – logic in `duplicate_finder.py` calculates similarity from stored tracks.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Scan a directory and populate the database:
+   ```bash
+   python sdc.py scan /path/to/music
+   ```
+3. List detected duplicates on the command line:
+   ```bash
+   python sdc.py duplicates
+   ```
+4. Run the web service for a browser UI:
+   ```bash
+   uvicorn sdc.api:app --reload
+   ```
+   Then visit [http://localhost:8000/scan](http://localhost:8000/scan) to start a scan and [http://localhost:8000/duplicates_table](http://localhost:8000/duplicates_table) to review matches.
+


### PR DESCRIPTION
## Summary
- document architecture with a mermaid diagram
- add usage instructions for CLI and running the API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688213825084832ca91cadce0d954df7