### PR TITLE
Improve scan feedback

### DIFF
--- a/src/sdc/api.py
+++ b/src/sdc/api.py
@@ -6,6 +6,7 @@ import os
 import sqlite3
 
 from .worker import start_scan, get_status
+from .scanner import AUDIO_EXTS
 from .database import open_db, Session
 from duplicate_finder import find_duplicates, _get_db_path
 from songripper.media import read_media_info
@@ -26,6 +27,19 @@ def health():
 def scan_page(request: Request) -> HTMLResponse:
     """Render the scan page."""
     return templates.TemplateResponse("scan.html", {"request": request})
+
+
+@app.get("/scan/check")
+def scan_check(root: str) -> dict[str, bool]:
+    """Return ``{"found": True}`` if ``root`` contains any audio file."""
+    path = Path(root)
+    try:
+        for p in path.rglob("*"):
+            if p.is_file() and p.suffix.lower() in AUDIO_EXTS:
+                return {"found": True}
+    except Exception:
+        pass
+    return {"found": False}
 
 
 @app.post("/scan")
@@ -59,7 +73,7 @@ def scan_progress(job_id: int) -> HTMLResponse:
             "<div class='w-full bg-gray-200 rounded-full h-4'>"
             f"<div class='bg-blue-600 h-4 rounded-full' style='width: {percent}%'></div>"
             "</div>"
-            f"<p class='text-sm mt-1'>{done}/{total} files</p>"
+            f"<p class='text-sm mt-1'>Scanning directory for new songs... {done}/{total} files</p>"
         )
     return HTMLResponse(html)
 

--- a/src/sdc/templates/scan.html
+++ b/src/sdc/templates/scan.html
@@ -26,13 +26,21 @@
         e.preventDefault();
         const form = e.target;
         const data = new FormData(form);
+        const root = data.get('root');
+        const progress = document.getElementById('progress');
+        progress.innerHTML = 'Checking NAS...';
+        const checkResp = await fetch(`/scan/check?root=${encodeURIComponent(root)}`);
+        const check = await checkResp.json();
+        if(!check.found){
+            progress.innerHTML = 'No song files found. Please check the NAS path.';
+            return;
+        }
+        progress.innerHTML = 'Found song successfully. Starting scan...';
         const resp = await fetch('/scan', {method: 'POST', body: data});
         const result = await resp.json();
-        const progress = document.getElementById('progress');
         progress.setAttribute('hx-get', `/scan/${result.task_id}/progress`);
         progress.setAttribute('hx-trigger', 'load, every 1s');
         progress.setAttribute('hx-swap', 'innerHTML');
-        progress.innerHTML = 'Starting scan...';
         htmx.process(progress);
     });
     </script>


### PR DESCRIPTION
## Summary
- add an endpoint to check for songs before scanning
- show NAS check in the scan form script
- display "Scanning directory for new songs" in progress bar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821ebb9ae8832c927b4c316e90b949