### PR TITLE
Update Dockerfile to launch new FastAPI app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && \
 WORKDIR /app
 COPY src /app/src
 ENV PYTHONPATH=/app/src
-CMD ["python", "-m", "main"]
+CMD ["uvicorn", "sdc.api:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- switch Dockerfile `CMD` to run the new `sdc.api` server

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882216d10f4832ca447c492dd94fbf6