### PR TITLE
Update Dockerfile to use sdc.api package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && \
 WORKDIR /app
 COPY src /app/src
 ENV PYTHONPATH=/app/src
-CMD ["python", "-m", "main"]
+CMD ["uvicorn", "sdc.api:app", "--host", "0.0.0.0", "--port", "8000", "--app-dir", "src"]


### PR DESCRIPTION
## Summary
- run uvicorn with `--app-dir src` so the `sdc` package is found before `sdc.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882216d10f4832ca447c492dd94fbf6