### PR TITLE
Auto-set scan path

### DIFF
--- a/src/sdc/api.py
+++ b/src/sdc/api.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import os
 import sqlite3
 
+from songripper.settings import NAS_PATH
+
 from .worker import start_scan, get_status
 from .scanner import AUDIO_EXTS
 from .database import open_db, Session
@@ -26,7 +28,9 @@ def health():
 @app.get("/scan", response_class=HTMLResponse)
 def scan_page(request: Request) -> HTMLResponse:
     """Render the scan page."""
-    return templates.TemplateResponse("scan.html", {"request": request})
+    return templates.TemplateResponse(
+        "scan.html", {"request": request, "nas_path": str(NAS_PATH)}
+    )
 
 
 @app.get("/scan/check")

--- a/src/sdc/templates/scan.html
+++ b/src/sdc/templates/scan.html
@@ -15,8 +15,7 @@
     </nav>
     <main class="container mx-auto px-4 py-6 flex-1">
         <form id="scan-form" class="mb-4">
-            <label for="root" class="block text-sm font-medium text-gray-700 mb-2">Root directory</label>
-            <input id="root" name="root" type="text" class="border p-2 w-full mb-2" />
+            <input id="root" name="root" type="hidden" value="{{ nas_path }}" />
             <button class="bg-blue-500 text-white px-4 py-2 rounded" type="submit">Start Scan</button>
         </form>
         <div id="progress"></div>


### PR DESCRIPTION
## Summary
- pass default NAS path to `scan.html`
- hide the root directory field and auto-fill with `/music`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e3d8db4c832cbdecfef534a1b242